### PR TITLE
Fix silver rupee counter not displaying in Ganon's castle

### DIFF
--- a/ASM/c/dungeon_info.c
+++ b/ASM/c/dungeon_info.c
@@ -8,7 +8,7 @@
 #include "item_effects.h"
 #include "save.h"
 
-int dungeon_count = 13;
+int dungeon_count = 14;
 
 dungeon_entry_t dungeons[] = {
     {  0, 0, 0, 0, 1, 0x0F, "Deku",       "Deku Tree",          {-1, -1, -1, -1}, {-1, -1, -1, -1} },


### PR DESCRIPTION
#2518 added an entry to the dungeons array, but forgot to increment the dungeon_count variable, which is used to iterate on this array by the silver rupee counter display function.
So it was not displaying anything for the last dungeon in the array which is Ganon's Castle.

## Testing
Shuffled Silver rupees, confirmed that the counter was not displayed in Ganon's castle at all.
Tested after this fix on Retroarch, and the counter is back.
