### PR TITLE
Don't display silver rupee counter if dungeon info is displayed

### DIFF
--- a/ASM/c/dungeon_info.c
+++ b/ASM/c/dungeon_info.c
@@ -110,7 +110,7 @@ int d_right_dungeon_idx(int i) {
 
 // When in a silver rupee room, draw the silver rupee count for that room.
 void draw_silver_rupee_count(z64_game_t* globalCtx, z64_disp_buf_t* db) {
-    if (!CFG_DUNGEON_INFO_SILVER_RUPEES) return;
+    if (!CFG_DUNGEON_INFO_SILVER_RUPEES || show_dungeon_info) return;
 
     uint8_t scene = globalCtx->scene_index;
     uint8_t room = globalCtx->room_index;


### PR DESCRIPTION
If you enable everything that makes the dungeon info screen larger (silver rupees + MQ + shuffle CMG keys), it goes left to the rupee/keys/silver rupee counter area, and since the silver rupee counter is drawn after the dungeon info screen, they overlap.
<img width="715" height="880" alt="image" src="https://github.com/user-attachments/assets/3cfe9c85-0c07-4b7c-8d06-5ef0a490a07e" />

An easy fix is just to not display the silver rupee counter is any dungeon info screen is on.
You could also display the counter first, then the info screen on top of it, but imo the information is not really important to keep on screen while the player is looking at the other dungeon info, and two of the dungeon info screens display the silver rupee count anyway.

## Testing
Tested on Retroarch that the silver rupee counter is not displayed anymore if any dungeon info screen is displayed.
