### PR TITLE
Avoid placing precompleted rewards on Rauru

### DIFF
--- a/World.py
+++ b/World.py
@@ -771,11 +771,16 @@ class World:
             boss_count -= 1
             random.shuffle(prizepool)
             random.shuffle(prize_locs)
-            loc = prize_locs.pop()
+            if self.settings.empty_dungeons_mode == 'rewards':
+                # Avoid placing a precompleted reward on Rauru so the number of precompleted dungeons matches the setting when possible.
+                # Python's `list.sort` is stable so rewards will still be shuffled properly other than that.
+                prizepool.sort(key=lambda reward: reward.name in self.settings.empty_dungeons_rewards, reverse=True) # precompleted rewards first
+                prize_locs.sort(key=lambda loc: loc.name == 'ToT Reward from Rauru') # reward from Rauru last
+            loc = prize_locs.pop(0)
             if self.settings.shuffle_dungeon_rewards == 'vanilla':
                 item = next(item for item in prizepool if item.name == location_table[loc.name][4])
             elif self.settings.shuffle_dungeon_rewards == 'reward':
-                item = prizepool.pop()
+                item = prizepool.pop(0)
             self.push_item(loc, item)
 
     def set_empty_dungeon_rewards(self, empty_rewards: list[str] = []) -> None:


### PR DESCRIPTION
Fixes a bug where, when “Pre-completed Dungeons Mode” is set to “Specific Rewards”, the randomizer could place one of the specified rewards on the `ToT Reward from Rauru` location, resulting in one fewer precompleted dungeon than expected.

This fix is conceptually similar to an existing feature where in “Count” mode, non-MQ dungeons are prioritized to be selected as precompleted before MQ dungeons.

## Testing

Tested using [ootrstats](https://github.com/fenhl/ootrstats) with a settings string that has the Kokiri Emerald and Goron Ruby precompleted:

* `ootrstats --settings=BSAWDNCAX2TB2XCHGABSL62ANAEACASSSACAASBEASHASFAAJAJUJJASCACC6AJXAQL6KT2LAASAGADWBRAJCEH7KYCAF3WQYAAAJLNBA3CGZA2SRES8WBTPAZCAEGJNQ6A6B6DJAJTA3JGE categorize '.locations["ToT Reward from Rauru"]'` reported that Rauru had the Kokiri Emerald in 1779 and the Goron Ruby in 1831 out of 16384 seeds, with 1 generator failure.
* `ootrstats -ufenhl -bprecompleted-rauru --settings=BSAWDNCAX2TB2XCHGABSL62ANAEACASSSACAASBEASHASFAAJAJUJJASCACC6AJXAQL6KT2LAASAGADWBRAJCEH7KYCAF3WQYAAAJLNBA3CGZA2SRES8WBTPAZCAEGJNQ6A6B6DJAJTA3JGE categorize '.locations["ToT Reward from Rauru"]'` reported no instances of Rauru holding either reward, with 0 generator failures.