### PR TITLE
Only run clean if build/bin exists

### DIFF
--- a/ASM/Makefile
+++ b/ASM/Makefile
@@ -26,7 +26,7 @@ RESOURCES = $(patsubst $(RESOURCEDIR)/%.bin,$(OBJDIR)/%_bin.o,$(sort $(wildcard 
 
 .PHONY: all clean bundle symbols
 
-all: clean bundle symbols
+all: bundle symbols
 
 $(OBJDIR)/%.o: %.c 
 	$(CC) -o $@ -c $< $(CFLAGS) $(CPPFLAGS)

--- a/ASM/build.py
+++ b/ASM/build.py
@@ -48,6 +48,8 @@ if base_rom_size != 0x400_0000:
 
 if compile_c:
     clist = ['make']
+    if os.path.isdir(os.path.join(run_dir, 'build', 'bin')):
+        call([*clist, 'clean'])
     clist.append(f'MIPS_BINUTILS_PREFIX={mips_binutils_prefix}')
     if debug_c:
         clist.append(f'DEBUG_MODE=1')


### PR DESCRIPTION
<!-- PR description goes here. If this fixes a bug or implements a feature for which an issue exists, use the exact words “Fixes #1000.” or “Closes #1000.” (replacing 1000 with the issue number) to have GitHub automatically link this PR to that issue. -->
Per discussion in dev-public-talk, `clean` shouldn't be an automated part of the makefile. It should be explicitly called or included in the build script. This checks to see if `build/bin` exists and calls `make clean` if it does
## Testing

<!-- What, if anything, have you tested? For ASM/C or GUI/web changes, consider including screenshots and/or videos. Note that it's totally fine to submit a PR without heavily testing it. If this PR would benefit from in-game testing but you can't test it yourself, consider posting a patch file to make testing easier for others. (You'll need to upload it inside a zip file since GitHub doesn't allow uploading .zpf files directly.) -->
Confirmed that `rm -rf build/bin/*.o` is only called if `build/bin` is an existing directory