### PR TITLE
Adjusted and fixed broken Barren hints for Scrubs Hints

### DIFF
--- a/data/Hints/scrubs.json
+++ b/data/Hints/scrubs.json
@@ -9,11 +9,9 @@
         { "location": "Deku Theater Skull Mask", "types": ["always"] }
     ],
     "remove_locations":      [
-        { "location": "the Haunted Wasteland", "types": ["barren"] },
-        { "location": "Hyrule Castle", "types": ["barren"] },
-        { "location": "Gerudo's Fortress", "types": ["barren"] },
-        { "location": "the Temple of Time", "types": ["barren"] },
-        { "location": "Ganons Castle", "types": ["barren"] },
+        { "location": "HAUNTED_WASTELAND", "types": ["barren"] },
+        { "location": "HYRULE_CASTLE", "types": ["barren"] },
+        { "location": "TEMPLE_OF_TIME", "types": ["barren"] },
         { "location": "ZR Frogs Ocarina Game", "types": ["always"] },
         { "location": "Gerudo Training Ground Maze Path Final Chest", "types": ["sometimes"] },
         { "location": "Ganons Castle Shadow Trial Golden Gauntlets Chest", "types": ["sometimes"] },


### PR DESCRIPTION
Fixed Syntax (#2441) to make sure they are indeed not possible to be hinted and made adjustments to balance to what Scrubs intends for their Tournament. 

Sidenote: Not sure how I should feel about the inconsistent Syntax in the same file, but I do prefer the new Language, it makes the regions less a pain to deal to figure out, instead of using their old version. 