### PR TITLE
Fix Hint Order for HF Valley Grotto Dual Hint

### DIFF
--- a/HintList.py
+++ b/HintList.py
@@ -1770,7 +1770,7 @@ hintTable: dict[str, tuple[list[str] | str, Optional[str], str | list[str]]] = {
 multiTable: dict[str, list[str]] = {
     'Deku Theater Rewards':                                     ['Deku Theater Skull Mask', 'Deku Theater Mask of Truth'],
     'HF Ocarina of Time Retrieval':                             ['HF Ocarina of Time Item', 'Song from Ocarina of Time'],
-    'HF Valley Grotto':                                         ['HF Cow Grotto Cow', 'HF GS Cow Grotto'],
+    'HF Valley Grotto':                                         ['HF GS Cow Grotto', 'HF Cow Grotto Cow'],
     'Market Bombchu Bowling Rewards':                           ['Market Bombchu Bowling First Prize', 'Market Bombchu Bowling Second Prize'],
     'ZR Frogs Rewards':                                         ['ZR Frogs in the Rain', 'ZR Frogs Ocarina Game'],
     'ZD Child Checks':                                          ['ZD Diving Minigame', 'ZD Chest'],


### PR DESCRIPTION
<!-- PR description goes here. If this fixes a bug or implements a feature for which an issue exists, use the exact words “Fixes #1000.” or “Closes #1000.” (replacing 1000 with the issue number) to have GitHub automatically link this PR to that issue. -->
The items hinted in this dual hint are currently hinted out of order relative to the current hint text. This change simply reverse the order that the items are hinted without affecting the prefix.
## Testing

<!-- What, if anything, have you tested? For ASM/C or GUI/web changes, consider including screenshots and/or videos. Note that it's totally fine to submit a PR without heavily testing it. If this PR would benefit from in-game testing but you can't test it yourself, consider posting a patch file to make testing easier for others. (You'll need to upload it inside a zip file since GitHub doesn't allow uploading .zpf files directly.) -->
Haven't been able to test because of the numpy bs from #2623 