### PR TITLE
Display venv creation log messages by default

### DIFF
--- a/OoTRandomizer.py
+++ b/OoTRandomizer.py
@@ -9,18 +9,15 @@ import logging
 import os
 import time
 
-from Utils import ensure_venv
+from Utils import ensure_venv, initialize_logger
 
 def start() -> None:
+    # Logging settings are also initialized with the venv!
     ensure_venv()
     from Main import main, from_patch_file, cosmetic_patch, diff_roms
     from Settings import get_settings_from_command_line_args
     from Utils import check_version, VersionError, local_path
-    settings, gui, args_loglevel, no_log_file, diff_rom = get_settings_from_command_line_args()
-
-    # set up logger
-    loglevel = {'error': logging.ERROR, 'info': logging.INFO, 'warning': logging.WARNING, 'debug': logging.DEBUG}[args_loglevel]
-    logging.basicConfig(format='%(message)s', level=loglevel)
+    settings, gui, no_log_file, diff_rom = get_settings_from_command_line_args()
 
     logger = logging.getLogger('')
 

--- a/Settings.py
+++ b/Settings.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import argparse
 import copy
 import hashlib
 import json
@@ -9,13 +8,12 @@ import random
 import re
 import string
 import sys
-import textwrap
 from collections.abc import Iterable
 from typing import Any, Optional
 
 import StartingItems
 from version import __version__
-from Utils import local_path, data_path
+from Utils import local_path, data_path, parse_command_line_args
 from SettingsList import SettingInfos, validate_settings, settings_versioning
 from Plandomizer import Distribution
 
@@ -24,13 +22,6 @@ LEGACY_STARTING_ITEM_SETTINGS: dict[str, dict[str, StartingItems.Entry]] = {
     'starting_inventory': StartingItems.inventory,
     'starting_songs': StartingItems.songs,
 }
-
-
-class ArgumentDefaultsHelpFormatter(argparse.RawTextHelpFormatter):
-
-    def _get_help_string(self, action) -> Optional[str]:
-        if  action.help is not None:
-            return textwrap.dedent(action.help)
 
 
 # 32 characters
@@ -404,21 +395,8 @@ class Settings(SettingInfos):
 
 
 # gets the randomizer settings, whether to open the gui, and the logger level from command line arguments
-def get_settings_from_command_line_args() -> tuple[Settings, bool, str, bool, str]:
-    parser = argparse.ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter)
-
-    parser.add_argument('--gui', help='Launch the GUI', action='store_true')
-    parser.add_argument('--loglevel', default='info', const='info', nargs='?', choices=['error', 'info', 'warning', 'debug'], help='Select level of logging for output.')
-    parser.add_argument('--settings_string', help='Provide sharable settings using a settings string. This will override all flags that it specifies.')
-    parser.add_argument('--convert_settings', help='Only convert the specified settings to a settings string. If a settings string is specified output the used settings instead.', action='store_true')
-    parser.add_argument('--settings', help='Use the specified settings file to use for generation')
-    parser.add_argument('--settings_preset', help="Use the given preset for base settings. Anything defined in the --settings file or the --settings_string will override the preset.")
-    parser.add_argument('--seed', help='Generate the specified seed.')
-    parser.add_argument('--no_log', help='Suppresses the generation of a log file.', action='store_true')
-    parser.add_argument('--output_settings', help='Always outputs a settings.json file even when spoiler is enabled.', action='store_true')
-    parser.add_argument('--diff_rom', help='Generates a ZPF patch from the specified ROM file.')
-
-    args, _ = parser.parse_known_args()
+def get_settings_from_command_line_args() -> tuple[Settings, bool, bool, str]:
+    args = parse_command_line_args()
     settings_base = {}
     if args.settings_preset:
         presetsFiles = get_preset_files()
@@ -474,4 +452,4 @@ def get_settings_from_command_line_args() -> tuple[Settings, bool, str, bool, st
             print(settings.get_settings_string())
         sys.exit(0)
 
-    return settings, args.gui, args.loglevel, args.no_log, args.diff_rom
+    return settings, args.gui, args.no_log, args.diff_rom

--- a/Utils.py
+++ b/Utils.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import argparse
 import io
 import json
 import logging
@@ -7,6 +8,7 @@ import platform
 import re
 import subprocess
 import sys
+import textwrap
 import urllib.request
 import venv
 from collections.abc import Sequence
@@ -241,6 +243,38 @@ def powerset(iterable):
     return chain.from_iterable(combinations(s, r) for r in range(len(s)+1))
 
 
+class ArgumentDefaultsHelpFormatter(argparse.RawTextHelpFormatter):
+
+    def _get_help_string(self, action) -> Optional[str]:
+        if  action.help is not None:
+            return textwrap.dedent(action.help)
+
+
+def parse_command_line_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter)
+
+    parser.add_argument('--gui', help='Launch the GUI', action='store_true')
+    parser.add_argument('--loglevel', default='info', const='info', nargs='?', choices=['error', 'info', 'warning', 'debug'], help='Select level of logging for output.')
+    parser.add_argument('--settings_string', help='Provide sharable settings using a settings string. This will override all flags that it specifies.')
+    parser.add_argument('--convert_settings', help='Only convert the specified settings to a settings string. If a settings string is specified output the used settings instead.', action='store_true')
+    parser.add_argument('--settings', help='Use the specified settings file to use for generation')
+    parser.add_argument('--settings_preset', help="Use the given preset for base settings. Anything defined in the --settings file or the --settings_string will override the preset.")
+    parser.add_argument('--seed', help='Generate the specified seed.')
+    parser.add_argument('--no_log', help='Suppresses the generation of a log file.', action='store_true')
+    parser.add_argument('--output_settings', help='Always outputs a settings.json file even when spoiler is enabled.', action='store_true')
+    parser.add_argument('--diff_rom', help='Generates a ZPF patch from the specified ROM file.')
+
+    args, _ = parser.parse_known_args()
+    return args
+
+
+def initialize_logger(args_loglevel: str):
+    # Python default log level is WARNING.
+    # Command line argument default is INFO.
+    loglevel = {'error': logging.ERROR, 'info': logging.INFO, 'warning': logging.WARNING, 'debug': logging.DEBUG}[args_loglevel]
+    logging.basicConfig(format='%(message)s', level=loglevel)
+
+
 def ensure_venv():
     if '--no-venv' in sys.argv:
         return
@@ -250,6 +284,10 @@ def ensure_venv():
     if platform.system() == 'Windows':
         PYTHON_BIN = os.path.abspath(os.path.join(VENV_DIR, "Scripts", "python.exe"))
     REQUIREMENTS = local_path("requirements.txt")
+
+    # Set up logger
+    args = parse_command_line_args()
+    initialize_logger(args.loglevel)
     logger = logging.getLogger('')
 
     # If venv doesn’t exist, create it


### PR DESCRIPTION
`ensure_venv()` has log messages to tell the user if it needs to install dependencies, but the messages were recently reported as not being shown. This happened because they were at `INFO` level, python's default is `WARNING`, and log level configuration using `INFO` as the default via a command line argument happened after venv creation.

This PR refactors command line argument parsing to separate it from randomizer settings parsing. Arguments are parsed at venv creation to allow log configuration before messages are logged.

Future changes could also display the pip status messages, but pip output also has to be captured currently to detect if all dependencies were installed. It looks possible to do via `Popen` instead of `subprocess.run`, but there are enough platform-specific quirks with these modules that I'm not confident changing methods without more rigorous testing. As-is, the PR is trivial IMO.

## Testing

Tested on Linux x86_64 with python 3.14.7. 