### PR TITLE
SGL 2026 preset update and altar Ganon BK hint with vanilla LACS crash

### DIFF
--- a/Hints.py
+++ b/Hints.py
@@ -2058,6 +2058,7 @@ def build_ganon_boss_key_string(world: World) -> str:
             if world.settings.lacs_condition == 'vanilla':
                 item_req_string = world.language.format_from_id("hint_text.ganon_req_vanilla")
                 count = 2
+                _, _, verb_singular, verb_plural = world.language.hint_text["ganon_medallions"]
             else:
                 count, singular, plural, verb_singular, verb_plural = {
                     'stones':     [world.settings.lacs_stones]+world.language.hint_text["ganon_stones"],

--- a/data/lang/English/property.json
+++ b/data/lang/English/property.json
@@ -9552,7 +9552,7 @@
             "is",
             "are"
         ],
-        "ganon_lacs_bk": "provided by Zelda once {item_req_string} {verb} retrieved",
+        "ganon_lacs_bk": "provided by Zelda once {item_req} {verb} retrieved",
         "ganon_medallions": [
             "#Medallion#",
             "#Medallions#",

--- a/data/lang/property_build.py
+++ b/data/lang/property_build.py
@@ -3202,7 +3202,7 @@ hint_text = {
     "ganon_dungeons": ("#Spiritual Stone or Medallion#", "#Spiritual Stones and Medallions#", "is", "are"),
     "ganon_tokens": ("#Gold Skulltula Token#", "#Gold Skulltula Tokens#", "is", "are"),
     "ganon_hearts": ("#heart#", "#hearts#", "is", "are"),
-    "ganon_lacs_bk": "provided by Zelda once {item_req_string} {verb} retrieved",
+    "ganon_lacs_bk": "provided by Zelda once {item_req} {verb} retrieved",
     "ganon_grant_bk": "automatically granted once {item_req} {verb} retrieved",
     "ganon_base": "And the \x05\x41evil one\x05\x40's key will be {bk_location_string}"
 }

--- a/data/presets_default.json
+++ b/data/presets_default.json
@@ -1129,7 +1129,7 @@
         "password_lock": false,
         "randomize_settings": false,
         "logic_rules": "glitchless",
-        "reachable_locations": "beatable",
+        "reachable_locations": "all",
         "triforce_hunt": false,
         "triforce_count_per_world": 28,
         "triforce_goal_per_world": 24,


### PR DESCRIPTION
SGL 2026 is going back to using all locations reachable instead of beatable only.  When switching back, I discovered a localization crash that only affects the SGL preset.

Generation crashes during ROM patching for any settings combination that uses **Ganon's Boss Key on LACS** with the **vanilla LACS condition** (Shadow + Spirit Medallions) while the **Temple of Time Altar** misc hint is enabled:

```
  Patches.py:1802   build_altar_hints(...)
  Hints.py:1947     adult_text += build_ganon_boss_key_string(world)
  Hints.py:2079     "verb": verb_singular if count == 1 else verb_plural
UnboundLocalError: cannot access local variable 'verb_plural' where it is not associated with a value
```

Two separate problems on the same code path, both introduced by the localization refactor in 56b50472a:

1. `build_ganon_boss_key_string()` unpacks `verb_singular` / `verb_plural` in the non-vanilla `lacs_condition` branch, but the `vanilla` branch assigns only `item_req_string` and `count`. Both branches then fall through to the shared `hint_text.ganon_lacs_bk` lookup, which reads the verbs — so the vanilla path raises `UnboundLocalError`. Fixed by binding the verbs from the `ganon_medallions` hint text, which matches the Shadow and Spirit Medallions that the vanilla condition actually requires, and keeps the strings translatable rather than hardcoding "is"/"are".

2. The English `ganon_lacs_bk` string references `{item_req_string}`, but the call site passes `item_req`. `Language._resolve_external` indexes the externals dict directly, so this would have raised `KeyError` as soon as the first bug was fixed. The Japanese string and the sibling `ganon_grant_bk` string both already use `{item_req}`, so this is just a typo in the one English entry. Fixed in `data/lang/property_build.py` and the generated `data/lang/English/property.json`.

The rendered text is unchanged from the pre-refactor behavior: `provided by Zelda once the #Shadow and Spirit Medallions# are retrieved`.

No preset shipped in `presets_default.json` on Dev hits this combination, which is why it went unnoticed — it was found via the SGL tournament preset that does.

## Testing

- Reproduced the crash with `shuffle_ganon_bosskey: on_lacs` + `lacs_condition: vanilla` + `altar` in `misc_hints`; confirmed it is deterministic and seed-independent.
- The same settings generate successfully after the fix (patch file, cosmetics log and spoiler log all written).
- Checked the rendered altar string in both English and Japanese. English matches the pre-refactor wording exactly; Japanese is unaffected, as its template does not use `{verb}`.
- `Unittest.TestLanguageFile` passes, covering key parity between `property_build.py` and the per-language `property.json` files.